### PR TITLE
Fixes makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ cours.pdf: cours.md default.latex
 # 	pandoc -s -o  $@ $< --toc --highlight-style kate --filter=pandoc-numbering --number-sections --filter=pandoc-crossref --template=./default.latex  --pdf-engine pdflatex -t epub3
 
 cours.html: cours.md Makefile
+	cd figs; ./convert.sh
 	pandoc -o $@ $< --toc --filter=pandoc-numbering --filter=pandoc-crossref --pdf-engine pdflatex -t html5 -c css/styling.css --self-contained --mathjax=MathJax.js
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ STYLES := css/tufte-css/tufte.css \
 all: cours.pdf cours.html
 
 cours.pdf: cours.md default.latex
+	cd figs; ./convert.sh
 	pandoc -s -o  $@ $< --toc --highlight-style kate --filter=pandoc-numbering --number-sections --filter=pandoc-crossref --template=./default.latex --pdf-engine pdflatex
 
 # cours.epub: cours.md default.latex


### PR DESCRIPTION
On a besoin d'appeler convert.sh. C'est maintenant chose faite : ce PR ajoute l'appel nécessaire.
☞   ͜ʖ  ☞